### PR TITLE
Unregister NavHost back stack manager when disposed

### DIFF
--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
@@ -74,6 +74,7 @@ fun NavHost(
         manager.setViewModelStore(viewModelStoreOwner.viewModelStore)
         manager.backDispatcher = backDispatcher
         onDispose {
+            backDispatcher?.unregister(manager)
             manager.lifeCycleOwner = null
         }
     }


### PR DESCRIPTION
When the NavHost is disposed its back stack manager needs to be unregistered. This should avoid leaks and incorrectly having invalid BackHandlers in the active handlers list.  