### PR TITLE
Fix broken swipe back

### DIFF
--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
@@ -35,7 +35,6 @@ import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
@@ -194,12 +193,11 @@ fun NavHost(
                                                     )
                                             }.drawWithContent {
                                                 drawContent()
-                                                if (actualSwipeProperties.drawShadow) {
-                                                    drawRect(
-                                                        Color.Black,
-                                                        alpha = (1f - dismissState.progress.fraction) / 6f
-                                                    )
-                                                }
+                                                drawRect(
+                                                    actualSwipeProperties.shadowColor,
+                                                    alpha = (1f - dismissState.progress.fraction) *
+                                                        actualSwipeProperties.shadowColor.alpha
+                                                )
                                             }.pointerInput(0) {
                                                 // prev entry should not be interactive until fully appeared
                                             }

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
@@ -148,7 +148,7 @@ fun NavHost(
                 prevWasSwiped = false
             }
 
-            val dismissState = key(currentEntry) {
+            val dismissState = key(currentSceneEntry) {
                 rememberDismissState {
                     if (it == DismissValue.DismissedToEnd) {
                         scope.launch {

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalMaterialApi::class)
-
 package moe.tlaster.precompose.navigation
 
 import androidx.compose.animation.AnimatedContent
@@ -126,8 +124,10 @@ fun NavHost(
     }
 
     Box(modifier) {
-        val currentSceneEntry by navigator.stackManager.currentSceneBackStackEntry.collectAsState(null)
-        val prevSceneEntry by navigator.stackManager.prevSceneBackStackEntry.collectAsState(null)
+        val currentSceneEntry by navigator.stackManager
+            .currentSceneBackStackEntry.collectAsState(null)
+        val prevSceneEntry by navigator.stackManager
+            .prevSceneBackStackEntry.collectAsState(null)
 
         val actualSwipeProperties = currentSceneEntry?.swipeProperties ?: swipeProperties
 
@@ -144,27 +144,20 @@ fun NavHost(
                 mutableStateOf(false)
             }
 
-            LaunchedEffect(currentEntry) {
-                delay(100)
+            LaunchedEffect(currentSceneEntry) {
                 prevWasSwiped = false
             }
 
-            val dismissState = key(currentSceneEntry) {
+            val dismissState = key(currentEntry) {
                 rememberDismissState {
-                    when (it) {
-                        DismissValue.DismissedToEnd -> {
-                            scope.launch {
-                                delay(200)
-                                prevWasSwiped = true
-                                navigator.goBack()
-                            }
-                            true
-                        }
-                        DismissValue.Default -> true
-                        DismissValue.DismissedToStart -> {
-                            true
+                    if (it == DismissValue.DismissedToEnd) {
+                        scope.launch {
+                            delay(200)
+                            prevWasSwiped = true
+                            navigator.goBack()
                         }
                     }
+                    true
                 }
             }
 
@@ -172,77 +165,58 @@ fun NavHost(
                 AnimatedContent(
                     it,
                     transitionSpec = {
-                        val actualTransaction = run {
-                            if (navigator.stackManager.contains(initialState)) targetState else initialState
-                        }.navTransition ?: navTransition
-
-                        if (!navigator.stackManager.contains(initialState)) {
-                            if (prevWasSwiped)
-                                EnterTransition.None with ExitTransition.None
-                            else
-                                actualTransaction.resumeTransition.with(actualTransaction.destroyTransition)
-                                    .apply {
-                                        targetContentZIndex =
-                                            actualTransaction.enterTargetContentZIndex
-                                    }
-                        } else {
-                            if (prevWasSwiped) {
-                                EnterTransition.None with ExitTransition.None
-                            } else {
-                                actualTransaction.createTransition.with(actualTransaction.pauseTransition)
-                                    .apply {
-                                        targetContentZIndex =
-                                            actualTransaction.exitTargetContentZIndex
-                                    }
-                            }
-                        }
+                        if (prevWasSwiped)
+                            EnterTransition.None with ExitTransition.None
+                        else transitionSpec()
                     }
                 ) { entry ->
 
-                    if (transition.isRunning) {
-                        NavHostContent(composeStateHolder, entry)
-                    } else {
-                        val showPrev by remember(dismissState) {
-                            derivedStateOf {
-                                dismissState.progress.fraction < 1
-                            }
-                        }
-
-                        if (showPrev && transition.isRunning.not()) {
-                            prevSceneEntry?.let { prev ->
-                                Box(
-                                    modifier = Modifier
-                                        .graphicsLayer {
-                                            translationX =
-                                                actualSwipeProperties.slideInHorizontally(size.width.toInt())
-                                                .toFloat() -
-                                                actualSwipeProperties.slideInHorizontally(
-                                                    dismissState.offset.value.absoluteValue.toInt()
-                                                )
-                                        }.drawWithContent {
-                                            drawContent()
-                                            if (actualSwipeProperties.drawShadow) {
-                                                drawRect(
-                                                    Color.Black,
-                                                    alpha = (1f - dismissState.progress.fraction) / 6f
-                                                )
-                                            }
-                                        }.pointerInput(0) {
-                                            // prev entry should not be interactive until fully appeared
-                                        }
-                                ) {
-                                    NavHostContent(composeStateHolder, prev)
+                    NavHostContent(composeStateHolder, entry) {
+                        if (transition.isRunning) {
+                            (entry.route as? ComposeRoute)?.content?.invoke(entry)
+                        } else {
+                            val showPrev by remember(dismissState) {
+                                derivedStateOf {
+                                    dismissState.progress.fraction < 1
                                 }
                             }
-                        }
 
-                        CustomSwipeToDismiss(
-                            state = dismissState,
-                            spaceToSwipe = actualSwipeProperties.spaceToSwipe,
-                            enabled = prevSceneEntry != null,
-                            dismissThreshold = actualSwipeProperties.swipeThreshold,
-                        ) {
-                            NavHostContent(composeStateHolder, entry)
+                            if (showPrev) {
+                                prevSceneEntry?.let { prev ->
+                                    Box(
+                                        modifier = Modifier
+                                            .graphicsLayer {
+                                                translationX =
+                                                    actualSwipeProperties.slideInHorizontally(size.width.toInt())
+                                                    .toFloat() -
+                                                    actualSwipeProperties.slideInHorizontally(
+                                                        dismissState.offset.value.absoluteValue.toInt()
+                                                    )
+                                            }.drawWithContent {
+                                                drawContent()
+                                                if (actualSwipeProperties.drawShadow) {
+                                                    drawRect(
+                                                        Color.Black,
+                                                        alpha = (1f - dismissState.progress.fraction) / 6f
+                                                    )
+                                                }
+                                            }.pointerInput(0) {
+                                                // prev entry should not be interactive until fully appeared
+                                            }
+                                    ) {
+                                        NavHostContent(composeStateHolder, prev)
+                                    }
+                                }
+                            }
+
+                            CustomSwipeToDismiss(
+                                state = dismissState,
+                                spaceToSwipe = actualSwipeProperties.spaceToSwipe,
+                                enabled = prevSceneEntry != null,
+                                dismissThreshold = actualSwipeProperties.swipeThreshold,
+                            ) {
+                                (entry.route as? ComposeRoute)?.content?.invoke(entry)
+                            }
                         }
                     }
                 }
@@ -260,7 +234,10 @@ fun NavHost(
 @Composable
 private fun NavHostContent(
     stateHolder: SaveableStateHolder,
-    entry: BackStackEntry
+    entry: BackStackEntry,
+    content: @Composable (() -> Unit) = {
+        (entry.route as? ComposeRoute)?.content?.invoke(entry)
+    }
 ) {
     DisposableEffect(entry) {
         entry.active()
@@ -272,11 +249,8 @@ private fun NavHostContent(
         CompositionLocalProvider(
             LocalStateHolder provides entry.stateHolder,
             LocalLifecycleOwner provides entry,
-        ) {
-            if (entry.route is ComposeRoute) {
-                entry.route.content.invoke(entry)
-            }
-        }
+            content = content
+        )
     }
 }
 

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/SwipeProperties.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/SwipeProperties.kt
@@ -5,6 +5,7 @@ package moe.tlaster.precompose.navigation
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FixedThreshold
 import androidx.compose.material.ThresholdConfig
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import moe.tlaster.precompose.navigation.transition.NavTransition
@@ -17,11 +18,12 @@ import moe.tlaster.precompose.navigation.transition.NavTransition
  * @param spaceToSwipe width of the swipe space from the left side of screen.
  * Can be set to [Int.MAX_VALUE].dp to enable full-scene swipe
  * @param swipeThreshold amount of offset to perform back navigation
- * @param drawShadow draw shadow on top of previous sliding entry
+ * @param shadowColor color of the shadow. Alpha channel is additionally multiplied
+ * by swipe progress. Use [Color.Transparent] to disable shadow
  * */
 class SwipeProperties(
     val slideInHorizontally: (fullWidth: Int) -> Int = { -it / 4 },
     val spaceToSwipe: Dp = 10.dp,
     val swipeThreshold: ThresholdConfig = FixedThreshold(56.dp),
-    val drawShadow: Boolean = true
+    val shadowColor: Color = Color.Black.copy(alpha = .25f)
 )


### PR DESCRIPTION
Fix #43 and remove some boilerplate code.

 `NavHostContent` was called multiple times to workaround a Compose bug when content is not displayed if it has negative offset. It didn't work well with route lifecycle.