### PR TITLE
Changing ComponentActivity to FragmentActivity

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -26,5 +26,6 @@ object Versions {
 
     object AndroidX {
         const val activity = "1.7.0"
+        const val appcompat = "1.6.1"
     }
 }

--- a/precompose/build.gradle.kts
+++ b/precompose/build.gradle.kts
@@ -59,6 +59,7 @@ kotlin {
                 implementation("androidx.compose.animation:animation:${Versions.compose}")
                 implementation("androidx.compose.material:material:${Versions.compose}")
                 api("androidx.activity:activity-ktx:${Versions.AndroidX.activity}")
+                api("androidx.appcompat:appcompat:${Versions.AndroidX.appcompat}")
                 implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
                 api("androidx.savedstate:savedstate-ktx:1.2.1")
             }

--- a/precompose/src/androidMain/kotlin/moe/tlaster/precompose/lifecycle/PreComposeActivity.kt
+++ b/precompose/src/androidMain/kotlin/moe/tlaster/precompose/lifecycle/PreComposeActivity.kt
@@ -2,7 +2,6 @@ package moe.tlaster.precompose.lifecycle
 
 import android.os.Bundle
 import android.view.ViewGroup
-import androidx.activity.ComponentActivity
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
@@ -11,6 +10,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
@@ -20,7 +20,7 @@ import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import moe.tlaster.precompose.stateholder.LocalStateHolder
 import moe.tlaster.precompose.ui.LocalBackDispatcherOwner
 
-open class PreComposeActivity : ComponentActivity() {
+open class PreComposeActivity : FragmentActivity() {
     internal val viewModel by viewModels<PreComposeViewModel>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
Changing ComponentActivity to FragmentActivity(which extends ComponentActivity) for supportFragmentManager access. This is required for BiometricPrompt for biometric login.