### PR TITLE
Flow & StateFlow extensions

### DIFF
--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/flow/FlowExtensions.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/flow/FlowExtensions.kt
@@ -31,10 +31,10 @@ fun <T : R, R> StateFlow<T>.collectAsStateWithLifecycle(
  */
 
 @Composable
-fun <T> Flow<T>.collectAsStateWithLifecycle(
-    initial: T,
+fun <T : R, R> Flow<T>.collectAsStateWithLifecycle(
+    initial: R,
     context: CoroutineContext = EmptyCoroutineContext
-): State<T> {
+): State<R> {
     val lifecycleOwner = checkNotNull(LocalLifecycleOwner.current)
     return collectAsStateWithLifecycle(
         initial = initial,
@@ -49,11 +49,11 @@ fun <T> Flow<T>.collectAsStateWithLifecycle(
  */
 
 @Composable
-fun <T> Flow<T>.collectAsStateWithLifecycle(
-    initial: T,
+fun <T: R, R> Flow<T>.collectAsStateWithLifecycle(
+    initial: R,
     lifecycle: Lifecycle,
     context: CoroutineContext = EmptyCoroutineContext
-): State<T> {
+): State<R> {
     return produceState(initial, this, lifecycle, context) {
         lifecycle.repeatOnLifecycle {
             if (context == EmptyCoroutineContext) {

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/flow/FlowExtensions.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/flow/FlowExtensions.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.produceState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.withContext
 import moe.tlaster.precompose.lifecycle.Lifecycle
 import moe.tlaster.precompose.lifecycle.LocalLifecycleOwner
@@ -62,4 +63,15 @@ fun <T> Flow<T>.collectAsStateWithLifecycle(
             }
         }
     }
+}
+
+fun <T> Flow<T>.flowWithLifecycle(
+    lifecycle: Lifecycle,
+): Flow<T> = callbackFlow {
+    lifecycle.repeatOnLifecycle {
+        this@flowWithLifecycle.collect {
+            send(it)
+        }
+    }
+    close()
 }

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/flow/FlowExtensions.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/flow/FlowExtensions.kt
@@ -49,7 +49,7 @@ fun <T : R, R> Flow<T>.collectAsStateWithLifecycle(
  */
 
 @Composable
-fun <T: R, R> Flow<T>.collectAsStateWithLifecycle(
+fun <T : R, R> Flow<T>.collectAsStateWithLifecycle(
     initial: R,
     lifecycle: Lifecycle,
     context: CoroutineContext = EmptyCoroutineContext

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/flow/FlowExtensions.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/flow/FlowExtensions.kt
@@ -2,36 +2,64 @@ package moe.tlaster.precompose.flow
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.produceState
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
 import moe.tlaster.precompose.lifecycle.Lifecycle
 import moe.tlaster.precompose.lifecycle.LocalLifecycleOwner
 import moe.tlaster.precompose.lifecycle.repeatOnLifecycle
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
+/**
+ * Collects values from this [StateFlow] and represents its latest value via [State] in a
+ * lifecycle-aware manner.
+ */
+
 @Composable
-fun <T : R, R> Flow<T>.collectAsStateWithLifecycle(
-    initial: R,
+fun <T : R, R> StateFlow<T>.collectAsStateWithLifecycle(
     context: CoroutineContext = EmptyCoroutineContext
 ): State<R> {
-    val lifecycleOwner = checkNotNull(LocalLifecycleOwner.current)
-    val flow = remember(this, lifecycleOwner) {
-        flowWithLifecycle(lifecycleOwner.lifecycle)
-    }
-    return flow.collectAsState(initial = initial, context = context)
+    return collectAsStateWithLifecycle(initial = this.value, context = context)
 }
 
-fun <T> Flow<T>.flowWithLifecycle(
+/**
+ * Collects values from this [Flow] and represents its latest value via [State] in a
+ * lifecycle-aware manner.
+ */
+
+@Composable
+fun <T> Flow<T>.collectAsStateWithLifecycle(
+    initial: T,
+    context: CoroutineContext = EmptyCoroutineContext
+): State<T> {
+    val lifecycleOwner = checkNotNull(LocalLifecycleOwner.current)
+    return collectAsStateWithLifecycle(
+        initial = initial,
+        lifecycle = lifecycleOwner.lifecycle,
+        context = context
+    )
+}
+
+/**
+ * Collects values from this [Flow] and represents its latest value via [State] in a
+ * lifecycle-aware manner.
+ */
+
+@Composable
+fun <T> Flow<T>.collectAsStateWithLifecycle(
+    initial: T,
     lifecycle: Lifecycle,
-): Flow<T> = callbackFlow {
-    lifecycle.repeatOnLifecycle {
-        this@flowWithLifecycle.collect {
-            send(it)
+    context: CoroutineContext = EmptyCoroutineContext
+): State<T> {
+    return produceState(initial, this, lifecycle, context) {
+        lifecycle.repeatOnLifecycle {
+            if (context == EmptyCoroutineContext) {
+                this@collectAsStateWithLifecycle.collect { this@produceState.value = it }
+            } else withContext(context) {
+                this@collectAsStateWithLifecycle.collect { this@produceState.value = it }
+            }
         }
     }
-    close()
 }

--- a/sample/todo/common/src/commonMain/kotlin/moe/tlaster/common/scene/NoteEditScene.kt
+++ b/sample/todo/common/src/commonMain/kotlin/moe/tlaster/common/scene/NoteEditScene.kt
@@ -15,10 +15,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import moe.tlaster.common.viewmodel.NoteEditViewModel
+import moe.tlaster.precompose.flow.collectAsStateWithLifecycle
 import moe.tlaster.precompose.viewmodel.viewModel
 
 @ExperimentalMaterialApi
@@ -61,8 +61,8 @@ fun NoteEditScene(
         }
     ) {
         Column {
-            val title by viewModel.title.collectAsState()
-            val content by viewModel.content.collectAsState()
+            val title by viewModel.title.collectAsStateWithLifecycle()
+            val content by viewModel.content.collectAsStateWithLifecycle()
             ListItem {
                 OutlinedTextField(
                     modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
Fixed that sometimes the "collectAsStateWithLifecycle" function didn't work immediately (For example, this is very noticeable using with TextField).
Added "collectAsStateWithLifecycle" extension function for StateFlow.
Changed the function "collectAsState" to "collectAsStateWithLifecycle" in the todo sample (NoteEditScene.kt).