### PR TITLE
Fix swipe recompositions

### DIFF
--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
@@ -156,10 +156,9 @@ fun NavHost(
                     }
                 }
 
-                val offset by dismissState.offset
-                val showPrev by remember(offset) {
+                val showPrev by remember(dismissState) {
                     derivedStateOf {
-                        offset > 0f
+                        dismissState.offset.value > 0f
                     }
                 }
 


### PR DESCRIPTION
Hi. 

Sorry for missing state preservation in swipe back navigation. Thanks for fixing it.

There is an infinite recompositions bug in your fix.  

P.S. Also there is an issue when swiped entry flashing after it was dismissed ( you can see it on last clip). Reproduces before this fix too.

Before:

https://github.com/Tlaster/PreCompose/assets/63979218/ac5048ae-5629-4951-b74f-b5e033cf3bab

After:

https://github.com/Tlaster/PreCompose/assets/63979218/d1654d0b-a6b3-4102-80e2-89e53f1b51a0

