### PR TITLE
Fix some issues (check description)

### DIFF
--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackStackManager.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackStackManager.kt
@@ -116,9 +116,9 @@ internal class BackStackManager : LifecycleObserver {
                 } else 0
             }
             if (index != -1) {
-                val stacks = currentBackStacks.subList(
+                val stacks = backStacks.value.subList(
                     if (popUpTo.inclusive) index else index + 1,
-                    currentBackStacks.size
+                    backStacks.value.size - 1
                 )
                 backStacks.value -= stacks
                 stacks.forEach {

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackStackManager.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackStackManager.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.map
 import moe.tlaster.precompose.lifecycle.Lifecycle
 import moe.tlaster.precompose.lifecycle.LifecycleObserver
 import moe.tlaster.precompose.lifecycle.LifecycleOwner
-import moe.tlaster.precompose.navigation.route.Route
 import moe.tlaster.precompose.navigation.route.SceneRoute
 import moe.tlaster.precompose.navigation.route.isFloatingRoute
 import moe.tlaster.precompose.navigation.route.isSceneRoute
@@ -107,21 +106,27 @@ internal class BackStackManager : LifecycleObserver {
         }
 
         if (options != null && options.popUpTo != PopUpTo.None) {
+            val backStack = if (options.launchSingleTop) {
+                backStacks.value.dropLast(1)
+            } else {
+                currentBackStacks
+            }
+
             val popUpTo = options.popUpTo
             val index = when (popUpTo) {
                 PopUpTo.None -> -1
-                PopUpTo.Prev -> currentBackStacks.lastIndex - 1
+                PopUpTo.Prev -> backStack.lastIndex - 1
                 is PopUpTo.Route -> if (popUpTo.route.isNotEmpty()) {
-                    currentBackStacks.indexOfLast { it.hasRoute(popUpTo.route, path, options.includePath) }
+                    backStack.indexOfLast { it.hasRoute(popUpTo.route, path, options.includePath) }
                 } else 0
             }
             if (index != -1) {
-                val stacks = backStacks.value.subList(
+                val stacksToDrop = backStack.subList(
                     if (popUpTo.inclusive) index else index + 1,
-                    backStacks.value.size - 1
+                    backStack.size
                 )
-                backStacks.value -= stacks
-                stacks.forEach {
+                backStacks.value -= stacksToDrop
+                stacksToDrop.forEach {
                     it.destroy()
                 }
             }

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/RouteBuilder.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/RouteBuilder.kt
@@ -5,6 +5,7 @@ import moe.tlaster.precompose.navigation.route.FloatingRoute
 import moe.tlaster.precompose.navigation.route.GroupRoute
 import moe.tlaster.precompose.navigation.route.Route
 import moe.tlaster.precompose.navigation.route.SceneRoute
+import moe.tlaster.precompose.navigation.route.isFloatingRoute
 import moe.tlaster.precompose.navigation.transition.NavTransition
 
 class RouteBuilder(
@@ -95,13 +96,10 @@ class RouteBuilder(
         this.route += route
     }
 
+    @Suppress("ControlFlowWithEmptyBody")
     internal fun build(): RouteGraph {
         if (initialRoute.isEmpty() && route.isEmpty()) {
             // FIXME: 2021/4/2 Show warning
-        } else {
-            require(route.any { it.route == initialRoute }) {
-                "No initial route target fot this route graph"
-            }
         }
         require(!route.groupBy { it.route }.any { it.value.size > 1 }) {
             "Duplicate route can not be applied"

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/RouteBuilder.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/RouteBuilder.kt
@@ -5,7 +5,6 @@ import moe.tlaster.precompose.navigation.route.FloatingRoute
 import moe.tlaster.precompose.navigation.route.GroupRoute
 import moe.tlaster.precompose.navigation.route.Route
 import moe.tlaster.precompose.navigation.route.SceneRoute
-import moe.tlaster.precompose.navigation.route.isFloatingRoute
 import moe.tlaster.precompose.navigation.transition.NavTransition
 
 class RouteBuilder(

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/ui/BackPressAdapter.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/ui/BackPressAdapter.kt
@@ -30,7 +30,7 @@ class BackDispatcher {
     }
 
     internal fun register(handler: BackHandler) {
-        handlers.add(0, handler)
+        handlers.add(handler)
     }
 
     internal fun unregister(handler: BackHandler) {

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/ui/BackPressAdapter.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/ui/BackPressAdapter.kt
@@ -31,10 +31,12 @@ class BackDispatcher {
 
     internal fun register(handler: BackHandler) {
         handlers.add(handler)
+        onBackStackChanged()
     }
 
     internal fun unregister(handler: BackHandler) {
         handlers.remove(handler)
+        onBackStackChanged()
     }
 }
 

--- a/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/BackStackManagerTest.kt
+++ b/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/BackStackManagerTest.kt
@@ -261,6 +261,38 @@ class BackStackManagerTest {
     }
 
     @Test
+    fun testMultipleLaunchSingleTopWithPopUpTo() {
+        val manager = BackStackManager()
+        manager.init(
+            RouteGraph(
+                "foo/bar",
+                listOf(
+                    TestRoute("foo/bar", "foo/bar"),
+                    TestRoute("foo/baz", "foo/baz"),
+                )
+            ),
+            StateHolder(),
+            TestLifecycleOwner()
+        )
+
+        fun navigate(path: String, navOptions: NavOptions) {
+            val previousEntry = manager.backStacks.value.lastOrNull()
+            manager.push(path, navOptions)
+            // Mark the previous entry as inactive to simulate the lifecycle change by the NavHost
+            previousEntry?.inActive()
+        }
+
+        navigate("foo/bar", NavOptions(launchSingleTop = true, popUpTo = PopUpTo.First(inclusive = true)))
+        navigate("foo/baz", NavOptions(launchSingleTop = true, popUpTo = PopUpTo.First(inclusive = false)))
+        navigate("foo/bar", NavOptions(launchSingleTop = true, popUpTo = PopUpTo.First(inclusive = true)))
+        navigate("foo/baz", NavOptions(launchSingleTop = true, popUpTo = PopUpTo.First(inclusive = false)))
+        val backStacks = manager.backStacks.value
+        assertEquals(2, backStacks.size)
+        assertEquals("foo/bar", backStacks[0].route.route)
+        assertEquals("foo/baz", backStacks[1].route.route)
+    }
+
+    @Test
     fun testLifecycle() {
         val manager = BackStackManager()
         val lifecycleOwner = TestLifecycleOwner()

--- a/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/RouteBuilderTest.kt
+++ b/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/RouteBuilderTest.kt
@@ -9,18 +9,6 @@ import kotlin.test.assertTrue
 
 class RouteBuilderTest {
     @Test
-    fun testInitialRouteNotInRoutes() {
-        assertFailsWith(IllegalArgumentException::class, "No initial route target fot this route graph") {
-            RouteBuilder("/home").build()
-        }
-        assertFailsWith(IllegalArgumentException::class, "No initial route target fot this route graph") {
-            RouteBuilder("/home").apply {
-                testRoute("/detail", "1")
-            }.build()
-        }
-    }
-
-    @Test
     fun testEmptyRoute() {
         val graph = RouteBuilder("").build()
         assertTrue(graph.routes.isEmpty())


### PR DESCRIPTION
Hi, first of all, thanks for working on this.

This PR attempts to fix some issues that I encountered while working with the library:

1. BackHandler doesn't work as expected, and I found two issues here:
    **i.** When we register the `backHandler`, we [add](https://github.com/Tlaster/PreCompose/blob/fb65985d99dcacbe9f057df42c061958212f5e43/precompose/src/commonMain/kotlin/moe/tlaster/precompose/ui/BackPressAdapter.kt#L33) it to the top of the list, while when we try to find the handler to use, we use the last one, and this means that the first attached handler will alway be used, instead of using the one from the current screen, I attempted to fix this with the commit 32e93641e004d74ad0bd758baed80e8077169bce

   **ii.** The `BackPressAdapter` state (I mean the `canHandleBackPress`) is [updated](https://github.com/Tlaster/PreCompose/blob/fb65985d99dcacbe9f057df42c061958212f5e43/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackHandler.kt#L24C1-L26) only when the default value of `enabled` of the `BackHandler` gets changed, and this means that for some cases, the `BackHandler` gets ignored completely: this happens excatly when we add a `BackHandler` to the first screen in the NavHost, because in this case, there were no prior enabled BackHandlers that would make the `canHandleBackPress` true, this should be fixed by the commit c989c6564479c64a393ba4a5cc86dbc54a5c6af2

To reproduce these issues, it's enough to add a `BackHandler` to the `NoteListScene` in the sample app, and you'll notice it doesn't do anything.

2. When using both `singleLaunchTop` and `popUpTo` in the NavOptions in two screens, the logic of the `popUpTo` gets broken, and leads to a crash.
A simple example to demonstrate this (the example attempts to simulate the behavior of Jetpack's [NavigationUI](https://developer.android.com/reference/androidx/navigation/ui/NavigationUI): the items pop the backstack to the first screen):
```kotlin
@Composable
fun App() {
    val navigator = rememberNavigator()
    MaterialTheme {

        Column {
            NavHost(
                navigator = navigator,
                initialRoute = "/screen1",
                modifier = Modifier.weight(1f)
            ) {
                scene("/screen1") {
                    Text("Screen 1")
                }
                scene("/screen2") {
                    Text("Screen 2")
                }
            }
            BottomNavigation {
                BottomNavigationItem(
                    selected = false,
                    onClick = {
                        navigator.navigate("/screen1",
                            NavOptions(
                                launchSingleTop = true,
                                popUpTo = PopUpTo.First()
                            )
                        )
                    },
                    icon = {
                        Text("Screen 1")
                    }
                )

                BottomNavigationItem(
                    selected = false,
                    onClick = {
                        navigator.navigate(
                            "/screen2",
                            NavOptions(
                                launchSingleTop = true,
                                popUpTo = PopUpTo.First(false)
                            )
                        )
                    },
                    icon = {
                        Text("Screen 2")
                    }
                )
            }
        }
    }
}
```
The commit a3078a53648db8340ad80c77d1bef9bfa8c77667 attempts to fix the second issue.