### PR TITLE
Add a way to save and restore data to the Saved State

### DIFF
--- a/precompose-viewmodel/src/commonMain/kotlin/moe/tlaster/precompose/viewmodel/ViewModelAdapter.kt
+++ b/precompose-viewmodel/src/commonMain/kotlin/moe/tlaster/precompose/viewmodel/ViewModelAdapter.kt
@@ -2,7 +2,9 @@ package moe.tlaster.precompose.viewmodel
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import moe.tlaster.precompose.stateholder.LocalSavedStateHolder
 import moe.tlaster.precompose.stateholder.LocalStateHolder
+import moe.tlaster.precompose.stateholder.SavedStateHolder
 import moe.tlaster.precompose.stateholder.StateHolder
 import kotlin.reflect.KClass
 
@@ -16,7 +18,7 @@ import kotlin.reflect.KClass
  */
 inline fun <reified T : ViewModel> viewModel(
     keys: List<Any?> = emptyList(),
-    noinline creator: () -> T,
+    noinline creator: (SavedStateHolder) -> T,
 ): T = viewModel(T::class, keys, creator = creator)
 
 /**
@@ -30,15 +32,20 @@ inline fun <reified T : ViewModel> viewModel(
 fun <T : ViewModel> viewModel(
     modelClass: KClass<T>,
     keys: List<Any?> = emptyList(),
-    creator: () -> T,
+    creator: (SavedStateHolder) -> T,
 ): T {
     val stateHolder = checkNotNull(LocalStateHolder.current) {
         "Require LocalStateHolder not null for $modelClass"
     }
+    val savedStateHolder = checkNotNull(LocalSavedStateHolder.current) {
+        "Require LocalSavedStateHolder not null"
+    }
     return remember(
-        modelClass, keys, creator, stateHolder
+        modelClass, keys, creator, stateHolder, savedStateHolder
     ) {
-        stateHolder.getViewModel(keys, modelClass = modelClass, creator = creator)
+        stateHolder.getViewModel(keys, modelClass = modelClass) {
+            creator(savedStateHolder)
+        }
     }
 }
 

--- a/precompose/src/androidMain/kotlin/moe/tlaster/precompose/lifecycle/PreComposeActivity.kt
+++ b/precompose/src/androidMain/kotlin/moe/tlaster/precompose/lifecycle/PreComposeActivity.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.findViewTreeLifecycleOwner
@@ -17,7 +19,9 @@ import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import moe.tlaster.precompose.stateholder.LocalSavedStateHolder
 import moe.tlaster.precompose.stateholder.LocalStateHolder
+import moe.tlaster.precompose.stateholder.SavedStateHolder
 import moe.tlaster.precompose.ui.LocalBackDispatcherOwner
 
 open class PreComposeActivity : FragmentActivity() {
@@ -97,6 +101,15 @@ private fun PreComposeActivity.ProvideAndroidCompositionLocals(
     content: @Composable () -> Unit,
 ) {
     val state by viewModel.backDispatcher.canHandleBackPress.collectAsState(false)
+
+    val saveableStateRegistry = LocalSaveableStateRegistry.current
+    val savedStateHolder = remember(saveableStateRegistry) {
+        SavedStateHolder(
+            "root",
+            saveableStateRegistry
+        )
+    }
+
     LaunchedEffect(state) {
         viewModel.backPressedCallback.isEnabled = state
     }
@@ -104,6 +117,7 @@ private fun PreComposeActivity.ProvideAndroidCompositionLocals(
         LocalLifecycleOwner provides this.viewModel,
         LocalStateHolder provides this.viewModel.stateHolder,
         LocalBackDispatcherOwner provides this.viewModel,
+        LocalSavedStateHolder provides savedStateHolder,
     ) {
         content.invoke()
     }

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackStackEntry.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackStackEntry.kt
@@ -7,6 +7,7 @@ import moe.tlaster.precompose.navigation.route.GroupRoute
 import moe.tlaster.precompose.navigation.route.Route
 import moe.tlaster.precompose.navigation.route.toSceneRoute
 import moe.tlaster.precompose.navigation.transition.NavTransition
+import moe.tlaster.precompose.stateholder.SavedStateHolder
 import moe.tlaster.precompose.stateholder.StateHolder
 
 class BackStackEntry internal constructor(
@@ -15,6 +16,7 @@ class BackStackEntry internal constructor(
     val path: String,
     val pathMap: Map<String, String>,
     private val parentStateHolder: StateHolder,
+    parentSavedStateHolder: SavedStateHolder,
     val queryString: QueryString? = null,
     // TODO: dirty callback for disabling push back -> immediate navigate
     private val requestNavigationLock: (locked: Boolean) -> Unit = {},
@@ -25,6 +27,7 @@ class BackStackEntry internal constructor(
     val stateHolder: StateHolder = parentStateHolder.getOrPut(stateId) {
         StateHolder()
     }
+    val savedStateHolder: SavedStateHolder = parentSavedStateHolder.child(stateId)
     internal val swipeProperties: SwipeProperties?
         get() = route.toSceneRoute()?.swipeProperties
 
@@ -57,6 +60,7 @@ class BackStackEntry internal constructor(
             lifecycleRegistry.currentState = Lifecycle.State.Destroyed
             stateHolder.close()
             parentStateHolder.remove(stateId)
+            savedStateHolder.close()
             uiClosable?.close(stateId)
             requestNavigationLock.invoke(false)
         }

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackStackManager.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackStackManager.kt
@@ -21,7 +21,7 @@ import kotlin.coroutines.suspendCoroutine
 internal const val STACK_SAVED_STATE_KEY = "BackStackManager"
 
 @Stable
-internal class BackStackManager: LifecycleObserver {
+internal class BackStackManager : LifecycleObserver {
     private lateinit var _stateHolder: StateHolder
     private lateinit var _savedStateHolder: SavedStateHolder
 

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
@@ -48,6 +48,7 @@ import moe.tlaster.precompose.lifecycle.LocalLifecycleOwner
 import moe.tlaster.precompose.navigation.route.ComposeRoute
 import moe.tlaster.precompose.navigation.route.GroupRoute
 import moe.tlaster.precompose.navigation.transition.NavTransition
+import moe.tlaster.precompose.stateholder.LocalSavedStateHolder
 import moe.tlaster.precompose.stateholder.LocalStateHolder
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
@@ -79,13 +80,16 @@ fun NavHost(
 ) {
     val lifecycleOwner = requireNotNull(LocalLifecycleOwner.current)
     val stateHolder = requireNotNull(LocalStateHolder.current)
+    val savedStateHolder = requireNotNull(LocalSavedStateHolder.current)
     val composeStateHolder = rememberSaveableStateHolder()
+
     // true for assuming that lifecycleOwner, stateHolder and composeStateHolder are not changing during the lifetime of the NavHost
     LaunchedEffect(true) {
         navigator.init(
             routeGraph = RouteBuilder(initialRoute).apply(builder).build(),
             stateHolder = stateHolder,
-            lifecycleOwner = lifecycleOwner,
+            savedStateHolder = savedStateHolder,
+            lifecycleOwner = lifecycleOwner
         )
     }
 
@@ -271,6 +275,7 @@ private fun NavHostContent(
     stateHolder.SaveableStateProvider(entry.stateId) {
         CompositionLocalProvider(
             LocalStateHolder provides entry.stateHolder,
+            LocalSavedStateHolder provides entry.savedStateHolder,
             LocalLifecycleOwner provides entry,
             content = {
                 entry.ComposeContent()

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
@@ -66,6 +66,7 @@ import kotlin.math.roundToInt
  * @param initialRoute the route for the start destination
  * @param navTransition navigation transition for the scenes in this [NavHost]
  * @param swipeProperties properties of swipe back navigation
+ * @param persistNavState whether to persist navigation state to the Saved State Registry, defaults to false
  * @param builder the builder used to construct the graph
  */
 @OptIn(ExperimentalAnimationApi::class, ExperimentalMaterialApi::class)
@@ -76,6 +77,7 @@ fun NavHost(
     initialRoute: String,
     navTransition: NavTransition = remember { NavTransition() },
     swipeProperties: SwipeProperties? = null,
+    persistNavState: Boolean = false,
     builder: RouteBuilder.() -> Unit,
 ) {
     val lifecycleOwner = requireNotNull(LocalLifecycleOwner.current)
@@ -89,7 +91,8 @@ fun NavHost(
             routeGraph = RouteBuilder(initialRoute).apply(builder).build(),
             stateHolder = stateHolder,
             savedStateHolder = savedStateHolder,
-            lifecycleOwner = lifecycleOwner
+            lifecycleOwner = lifecycleOwner,
+            persistNavState = persistNavState,
         )
     }
 

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/Navigator.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/Navigator.kt
@@ -30,6 +30,7 @@ class Navigator {
         stateHolder: StateHolder,
         savedStateHolder: SavedStateHolder,
         lifecycleOwner: LifecycleOwner,
+        persistNavState: Boolean,
     ) {
         if (_initialized) {
             return
@@ -39,7 +40,8 @@ class Navigator {
             routeGraph = routeGraph,
             stateHolder = stateHolder,
             savedStateHolder = savedStateHolder,
-            lifecycleOwner = lifecycleOwner
+            lifecycleOwner = lifecycleOwner,
+            persistNavState = persistNavState
         )
         _pendingNavigation?.let {
             stackManager.push(it)

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/Navigator.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/Navigator.kt
@@ -3,6 +3,7 @@ package moe.tlaster.precompose.navigation
 import androidx.compose.runtime.Composable
 import moe.tlaster.precompose.lifecycle.LifecycleOwner
 import moe.tlaster.precompose.stateholder.LocalStateHolder
+import moe.tlaster.precompose.stateholder.SavedStateHolder
 import moe.tlaster.precompose.stateholder.StateHolder
 
 /**
@@ -27,6 +28,7 @@ class Navigator {
     internal fun init(
         routeGraph: RouteGraph,
         stateHolder: StateHolder,
+        savedStateHolder: SavedStateHolder,
         lifecycleOwner: LifecycleOwner,
     ) {
         if (_initialized) {
@@ -36,7 +38,8 @@ class Navigator {
         stackManager.init(
             routeGraph = routeGraph,
             stateHolder = stateHolder,
-            lifecycleOwner = lifecycleOwner,
+            savedStateHolder = savedStateHolder,
+            lifecycleOwner = lifecycleOwner
         )
         _pendingNavigation?.let {
             stackManager.push(it)

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/stateholder/SavedStateHolder.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/stateholder/SavedStateHolder.kt
@@ -1,0 +1,38 @@
+package moe.tlaster.precompose.stateholder
+
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+
+/**
+ * Allows components to save and restore their state using the saved instance state mechanism,
+ * which can be useful in some platforms such as Android.
+ *
+ * @param key The key used scope the state in the provided [saveableStateRegistry].
+ * @param saveableStateRegistry The parent [SaveableStateRegistry] to use for saving and restoring
+ */
+@OptIn(ExperimentalStdlibApi::class)
+@Suppress("UNCHECKED_CAST")
+class SavedStateHolder(
+    private val key: String,
+    private val saveableStateRegistry: SaveableStateRegistry?
+) : SaveableStateRegistry by SaveableStateRegistry(
+    saveableStateRegistry?.consumeRestored(key) as? Map<String, List<Any?>>,
+    { saveableStateRegistry?.canBeSaved(it) ?: true }
+), AutoCloseable {
+    private val registryEntry = saveableStateRegistry?.registerProvider(key) {
+        performSave()
+    }
+
+    fun child(key: String): SavedStateHolder {
+        return SavedStateHolder(key, this)
+    }
+
+    override fun close() {
+        registryEntry?.unregister()
+    }
+}
+
+val LocalSavedStateHolder = compositionLocalOf {
+    // A default implementation for platforms that don't offer a [SaveableStateRegistry]
+    SavedStateHolder("root", null)
+}

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/stateholder/SavedStateHolder.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/stateholder/SavedStateHolder.kt
@@ -18,7 +18,8 @@ class SavedStateHolder(
 ) : SaveableStateRegistry by SaveableStateRegistry(
     saveableStateRegistry?.consumeRestored(key) as? Map<String, List<Any?>>,
     { saveableStateRegistry?.canBeSaved(it) ?: true }
-), AutoCloseable {
+),
+    AutoCloseable {
     private val registryEntry = saveableStateRegistry?.registerProvider(key) {
         performSave()
     }

--- a/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/BackStackEntryTest.kt
+++ b/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/BackStackEntryTest.kt
@@ -17,6 +17,7 @@ class BackStackEntryTest {
             "foo/bar",
             emptyMap(),
             parentStateHolder,
+            TestSavedStateHolder()
         )
         assertTrue(parentStateHolder.contains(entry.stateId))
         assertEquals(Lifecycle.State.Initialized, entry.lifecycle.currentState)
@@ -33,6 +34,7 @@ class BackStackEntryTest {
             "foo/bar",
             emptyMap(),
             parentStateHolder,
+            TestSavedStateHolder()
         )
         entry.active()
         assertEquals(Lifecycle.State.Active, entry.lifecycle.currentState)
@@ -50,6 +52,7 @@ class BackStackEntryTest {
             "foo/bar",
             emptyMap(),
             parentStateHolder,
+            TestSavedStateHolder()
         )
         entry.active()
         assertEquals(Lifecycle.State.Active, entry.lifecycle.currentState)
@@ -69,6 +72,7 @@ class BackStackEntryTest {
             "foo/bar",
             emptyMap(),
             parentStateHolder,
+            TestSavedStateHolder()
         )
         entry.active()
         entry.destroy()

--- a/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/BackStackManagerTest.kt
+++ b/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/BackStackManagerTest.kt
@@ -15,7 +15,7 @@ class BackStackManagerTest {
     fun testInitialRoute() {
         val manager = BackStackManager()
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -23,9 +23,10 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-            TestSavedStateHolder(),
-            TestLifecycleOwner()
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = TestLifecycleOwner(),
+            persistNavState = false
         )
         val backStacks = manager.backStacks.value
         assertEquals(1, backStacks.size)
@@ -38,7 +39,7 @@ class BackStackManagerTest {
     fun testPush() {
         val manager = BackStackManager()
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -46,9 +47,10 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-            TestSavedStateHolder(),
-            TestLifecycleOwner()
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = TestLifecycleOwner(),
+            persistNavState = false
         )
         manager.push("foo/bar/1")
         val backStacks = manager.backStacks.value
@@ -63,7 +65,7 @@ class BackStackManagerTest {
     fun testPop() {
         val manager = BackStackManager()
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -71,9 +73,10 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-            TestSavedStateHolder(),
-            TestLifecycleOwner(),
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = TestLifecycleOwner(),
+            persistNavState = false
         )
         manager.push("foo/bar/1")
         manager.push("foo/bar/1/baz")
@@ -90,7 +93,7 @@ class BackStackManagerTest {
     fun testLaunchSingleTop() {
         val manager = BackStackManager()
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -98,9 +101,10 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-            TestSavedStateHolder(),
-            TestLifecycleOwner(),
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = TestLifecycleOwner(),
+            persistNavState = false
         )
         manager.push("foo/bar/1")
         manager.push("foo/bar/1/baz")
@@ -124,7 +128,7 @@ class BackStackManagerTest {
     fun testLaunchSingleTopWithIncludePath() {
         val manager = BackStackManager()
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -132,9 +136,10 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-
-            TestSavedStateHolder(), TestLifecycleOwner(),
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = TestLifecycleOwner(),
+            persistNavState = false
         )
         manager.push("foo/bar/1")
         manager.push("foo/bar/1/baz")
@@ -155,7 +160,7 @@ class BackStackManagerTest {
     fun testPopUpTo() {
         val manager = BackStackManager()
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -163,9 +168,10 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-
-            TestSavedStateHolder(), TestLifecycleOwner(),
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = TestLifecycleOwner(),
+            persistNavState = false
         )
         manager.push("foo/bar/1")
         manager.push("foo/bar/1/baz")
@@ -186,7 +192,7 @@ class BackStackManagerTest {
     fun testPopUpToWithInclusiveLast() {
         val manager = BackStackManager()
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -194,9 +200,10 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-
-            TestSavedStateHolder(), TestLifecycleOwner(),
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = TestLifecycleOwner(),
+            persistNavState = false
         )
         manager.push("foo/bar/1")
         manager.push("foo/bar/1/baz")
@@ -217,7 +224,7 @@ class BackStackManagerTest {
     fun testPopUpToWithInclusive() {
         val manager = BackStackManager()
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -225,9 +232,10 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-
-            TestSavedStateHolder(), TestLifecycleOwner(),
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = TestLifecycleOwner(),
+            persistNavState = false
         )
         manager.push("foo/bar/1")
         manager.push("foo/bar/1/baz")
@@ -249,7 +257,7 @@ class BackStackManagerTest {
     fun testLaunchSingleTopWithPopUpToWithInclusive() {
         val manager = BackStackManager()
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -257,9 +265,10 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-            TestSavedStateHolder(),
-            TestLifecycleOwner(),
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = TestLifecycleOwner(),
+            persistNavState = false
         )
         manager.push("foo/bar/1")
         manager.push("foo/bar/1/baz")
@@ -277,7 +286,7 @@ class BackStackManagerTest {
         val manager = BackStackManager()
         val lifecycleOwner = TestLifecycleOwner()
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -285,9 +294,10 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-            TestSavedStateHolder(),
-            lifecycleOwner,
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = lifecycleOwner,
+            persistNavState = false
         )
         val entry = manager.backStacks.value[0]
         lifecycleOwner.lifecycle.currentState = Lifecycle.State.Active
@@ -304,7 +314,7 @@ class BackStackManagerTest {
         val manager = BackStackManager()
         val lifecycleOwner = TestLifecycleOwner()
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -312,9 +322,10 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-            TestSavedStateHolder(),
-            lifecycleOwner
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = lifecycleOwner,
+            persistNavState = false
         )
         assertTrue(manager.canNavigate)
         var currentEntry = manager.backStacks.value.last()
@@ -334,15 +345,16 @@ class BackStackManagerTest {
         val manager = BackStackManager()
         val lifecycleOwner = TestLifecycleOwner()
         manager.init(
-            RouteBuilder("/home").apply {
+            routeGraph = RouteBuilder("/home").apply {
                 testRoute("/home", "home")
                 group("/group", "/detail") {
                     testRoute("/detail", "detail")
                 }
             }.build(),
-            StateHolder(),
-            TestSavedStateHolder(),
-            lifecycleOwner
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = lifecycleOwner,
+            persistNavState = false
         )
         manager.push("/group")
         assertEquals(2, manager.backStacks.value.size)
@@ -358,7 +370,7 @@ class BackStackManagerTest {
         val manager = BackStackManager()
         val lifecycleOwner = TestLifecycleOwner()
         manager.init(
-            RouteBuilder("/home").apply {
+            routeGraph = RouteBuilder("/home").apply {
                 testRoute("/home", "home")
                 group("/group", "/detail") {
                     testRoute("/detail", "detail")
@@ -367,9 +379,10 @@ class BackStackManagerTest {
                     }
                 }
             }.build(),
-            StateHolder(),
-            TestSavedStateHolder(),
-            lifecycleOwner
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = lifecycleOwner,
+            persistNavState = false
         )
         manager.push("/group")
         assertEquals(2, manager.backStacks.value.size)
@@ -393,15 +406,16 @@ class BackStackManagerTest {
         val manager = BackStackManager()
         val lifecycleOwner = TestLifecycleOwner()
         manager.init(
-            RouteBuilder("/home").apply {
+            routeGraph = RouteBuilder("/home").apply {
                 testRoute("/home", "home")
                 group("/group", "/detail") {
                     testRoute("/detail", "detail")
                 }
             }.build(),
-            StateHolder(),
-            TestSavedStateHolder(),
-            lifecycleOwner
+            stateHolder = StateHolder(),
+            savedStateHolder = TestSavedStateHolder(),
+            lifecycleOwner = lifecycleOwner,
+            persistNavState = false
         )
         manager.push("/group")
         assertEquals(2, manager.backStacks.value.size)
@@ -423,7 +437,7 @@ class BackStackManagerTest {
         val saveableStateHolder = TestSavedStateHolder()
 
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -431,9 +445,10 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-            saveableStateHolder,
-            lifecycleOwner
+            stateHolder = StateHolder(),
+            savedStateHolder = saveableStateHolder,
+            lifecycleOwner = lifecycleOwner,
+            persistNavState = true
         )
 
         manager.push("foo/bar/1")
@@ -458,7 +473,7 @@ class BackStackManagerTest {
         )
 
         manager.init(
-            RouteGraph(
+            routeGraph = RouteGraph(
                 "foo/bar",
                 listOf(
                     TestRoute("foo/bar", "foo/bar"),
@@ -466,14 +481,47 @@ class BackStackManagerTest {
                     TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
                 )
             ),
-            StateHolder(),
-            savedStateHolder,
-            lifecycleOwner
+            stateHolder = StateHolder(),
+            savedStateHolder = savedStateHolder,
+            lifecycleOwner = lifecycleOwner,
+            persistNavState = true
         )
 
         assertEquals(
             listOf("foo/bar", "foo/bar/1", "foo/bar/1/baz"),
             manager.backStacks.value.map { it.path }
         )
+    }
+
+    @Test
+    fun testBackStackNotPersistedWhenDisabled() {
+        val manager = BackStackManager()
+        val lifecycleOwner = TestLifecycleOwner()
+        val saveableStateHolder = TestSavedStateHolder()
+
+        manager.init(
+            routeGraph = RouteGraph(
+                "foo/bar",
+                listOf(
+                    TestRoute("foo/bar", "foo/bar"),
+                    TestRoute("foo/bar/{id}", "foo/bar/{id}"),
+                    TestRoute("foo/bar/{id}/baz", "foo/bar/{id}/baz"),
+                )
+            ),
+            stateHolder = StateHolder(),
+            savedStateHolder = saveableStateHolder,
+            lifecycleOwner = lifecycleOwner,
+            persistNavState = false
+        )
+
+        manager.push("foo/bar/1")
+        manager.push("foo/bar/1/baz")
+
+        saveableStateHolder.performSave().apply {
+            assertEquals(
+                null,
+                get(STACK_SAVED_STATE_KEY)
+            )
+        }
     }
 }

--- a/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/NavigatorTest.kt
+++ b/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/NavigatorTest.kt
@@ -19,6 +19,7 @@ class NavigatorTest {
                 )
             ),
             StateHolder(),
+            TestSavedStateHolder(),
             TestLifecycleOwner(),
         )
         navigator.navigate("foo/bar/1")
@@ -43,7 +44,8 @@ class NavigatorTest {
                 )
             ),
             StateHolder(),
-            TestLifecycleOwner(),
+            TestSavedStateHolder(),
+            TestLifecycleOwner()
         )
         assertEquals(2, navigator.stackManager.backStacks.value.size)
         assertEquals("foo/bar/{id}", navigator.stackManager.backStacks.value.last().route.route)

--- a/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/NavigatorTest.kt
+++ b/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/NavigatorTest.kt
@@ -21,6 +21,7 @@ class NavigatorTest {
             StateHolder(),
             TestSavedStateHolder(),
             TestLifecycleOwner(),
+            false
         )
         navigator.navigate("foo/bar/1")
         navigator.navigate("foo/bar/1/baz")
@@ -45,7 +46,8 @@ class NavigatorTest {
             ),
             StateHolder(),
             TestSavedStateHolder(),
-            TestLifecycleOwner()
+            TestLifecycleOwner(),
+            false
         )
         assertEquals(2, navigator.stackManager.backStacks.value.size)
         assertEquals("foo/bar/{id}", navigator.stackManager.backStacks.value.last().route.route)

--- a/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/SeavableStateRegistry.kt
+++ b/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/SeavableStateRegistry.kt
@@ -1,0 +1,15 @@
+package moe.tlaster.precompose.navigation
+
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+import moe.tlaster.precompose.stateholder.SavedStateHolder
+
+@Suppress("TestFunctionName")
+internal fun TestSavedStateHolder(
+    restored: Map<String, List<Any?>>? = null
+) = SavedStateHolder(
+    key = "key",
+    saveableStateRegistry = SaveableStateRegistry(
+        restoredValues = mapOf("key" to listOf(restored)),
+        canBeSaved = { true }
+    )
+)

--- a/sample/todo/common/src/commonMain/kotlin/moe/tlaster/common/App.kt
+++ b/sample/todo/common/src/commonMain/kotlin/moe/tlaster/common/App.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import moe.tlaster.common.scene.NoteDetailScene
 import moe.tlaster.common.scene.NoteEditScene
 import moe.tlaster.common.scene.NoteListScene

--- a/sample/todo/common/src/commonMain/kotlin/moe/tlaster/common/scene/NoteEditScene.kt
+++ b/sample/todo/common/src/commonMain/kotlin/moe/tlaster/common/scene/NoteEditScene.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import moe.tlaster.common.viewmodel.NoteEditViewModel
 import moe.tlaster.precompose.flow.collectAsStateWithLifecycle
-import moe.tlaster.precompose.stateholder.LocalSavedStateHolder
 import moe.tlaster.precompose.viewmodel.viewModel
 
 @ExperimentalMaterialApi
@@ -29,8 +28,7 @@ fun NoteEditScene(
     onDone: () -> Unit = {},
     onBack: () -> Unit = {},
 ) {
-    val savedSateHolder = LocalSavedStateHolder.current
-    val viewModel = viewModel(NoteEditViewModel::class, listOf(id, savedSateHolder)) {
+    val viewModel = viewModel(NoteEditViewModel::class, listOf(id)) { savedSateHolder ->
         NoteEditViewModel(id, savedSateHolder)
     }
 

--- a/sample/todo/common/src/commonMain/kotlin/moe/tlaster/common/scene/NoteEditScene.kt
+++ b/sample/todo/common/src/commonMain/kotlin/moe/tlaster/common/scene/NoteEditScene.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import moe.tlaster.common.viewmodel.NoteEditViewModel
 import moe.tlaster.precompose.flow.collectAsStateWithLifecycle
+import moe.tlaster.precompose.stateholder.LocalSavedStateHolder
 import moe.tlaster.precompose.viewmodel.viewModel
 
 @ExperimentalMaterialApi
@@ -28,8 +29,9 @@ fun NoteEditScene(
     onDone: () -> Unit = {},
     onBack: () -> Unit = {},
 ) {
-    val viewModel = viewModel(NoteEditViewModel::class, listOf(id)) {
-        NoteEditViewModel(id)
+    val savedSateHolder = LocalSavedStateHolder.current
+    val viewModel = viewModel(NoteEditViewModel::class, listOf(id, savedSateHolder)) {
+        NoteEditViewModel(id, savedSateHolder)
     }
 
     Scaffold(

--- a/sample/todo/common/src/commonMain/kotlin/moe/tlaster/common/viewmodel/NoteEditViewModel.kt
+++ b/sample/todo/common/src/commonMain/kotlin/moe/tlaster/common/viewmodel/NoteEditViewModel.kt
@@ -2,10 +2,12 @@ package moe.tlaster.common.viewmodel
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import moe.tlaster.common.repository.FakeRepository
+import moe.tlaster.precompose.stateholder.SavedStateHolder
 import moe.tlaster.precompose.viewmodel.ViewModel
 
 class NoteEditViewModel(
     private val id: Int?,
+    savedStateHolder: SavedStateHolder
 ) : ViewModel() {
 
     private val note by lazy {
@@ -16,8 +18,17 @@ class NoteEditViewModel(
         }
     }
 
-    val title = MutableStateFlow(note?.title ?: "")
-    val content = MutableStateFlow(note?.content ?: "")
+    val title = MutableStateFlow(savedStateHolder.consumeRestored("title") as String? ?: note?.title ?: "")
+    val content = MutableStateFlow(savedStateHolder.consumeRestored("content") as String? ?: note?.content ?: "")
+
+    init {
+        savedStateHolder.registerProvider("title") {
+            title.value
+        }
+        savedStateHolder.registerProvider("content") {
+            content.value
+        }
+    }
 
     fun setTitle(value: String) {
         title.value = value


### PR DESCRIPTION
The currently implemented `StateHolder` saves components only during configuration changes, this PR adds an additional component to allow saving some state to be persisted during process-death in Android too, it's done in a similar way to `StateHolder`, the app will have a root `SavedStateHolder`, and each `BackStackEntry` will have its own copy, this allows scoping keys too to avoid the chance of having duplicate keys saved.

The implementation uses `SaveableStateRegistry`, it's quite simple, and it doesn't impact platforms that don't implement it (basically all platforms except Android).

Client apps are responsible of checking whether the component can save the data, and we can even add a way to Parcelize classes in the library to make this easier, but it's outside of the scope of this PR I think.

In addition to the above, I exploited the component in order to save the back stack of the navigator during process-death too, to test this, just enable "Don't keep activities" from the developer options in Android, then navigate from and back to the app, and confirm that the back stack was persisted.