### PR TITLE
Compose 1.5.0 beta, Kotlin 1.9.0, minor Coroutines and AndroidX Activity version

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -11,7 +11,7 @@ object Versions {
 
     object Kotlin {
         const val lang = "1.9.0"
-        const val coroutines = "1.7.1"
+        const val coroutines = "1.7.2"
     }
 
     object Java {
@@ -25,7 +25,7 @@ object Versions {
     const val compose_jb = "1.5.0-dev1122"
 
     object AndroidX {
-        const val activity = "1.7.0"
+        const val activity = "1.7.2"
         const val appcompat = "1.6.1"
     }
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -10,7 +10,7 @@ object Versions {
     }
 
     object Kotlin {
-        const val lang = "1.8.20"
+        const val lang = "1.9.0"
         const val coroutines = "1.7.1"
     }
 
@@ -21,8 +21,8 @@ object Versions {
 
     const val spotless = "6.7.0"
     const val ktlint = "0.45.2"
-    const val compose = "1.4.2"
-    const val compose_jb = "1.4.0"
+    const val compose = "1.5.0-beta03"
+    const val compose_jb = "1.5.0-dev1122"
 
     object AndroidX {
         const val activity = "1.7.0"

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
@@ -1,12 +1,12 @@
 package moe.tlaster.precompose.navigation
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.animation.with
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -96,16 +96,16 @@ fun NavHost(
         )
     }
 
-    val transitionSpec: AnimatedContentScope<BackStackEntry>.() -> ContentTransform = {
+    val transitionSpec: AnimatedContentTransitionScope<BackStackEntry>.() -> ContentTransform = {
         val actualTransaction = run {
             if (navigator.stackManager.contains(initialState)) targetState else initialState
         }.navTransition ?: navTransition
         if (!navigator.stackManager.contains(initialState)) {
-            actualTransaction.resumeTransition.with(actualTransaction.destroyTransition).apply {
+            actualTransaction.resumeTransition.togetherWith(actualTransaction.destroyTransition).apply {
                 targetContentZIndex = actualTransaction.enterTargetContentZIndex
             }
         } else {
-            actualTransaction.createTransition.with(actualTransaction.pauseTransition).apply {
+            actualTransaction.createTransition.togetherWith(actualTransaction.pauseTransition).apply {
                 targetContentZIndex = actualTransaction.exitTargetContentZIndex
             }
         }
@@ -186,7 +186,7 @@ fun NavHost(
                         backStackEntry,
                         transitionSpec = {
                             if (prevWasSwiped) {
-                                EnterTransition.None with ExitTransition.None
+                                EnterTransition.None togetherWith ExitTransition.None
                             } else {
                                 transitionSpec()
                             }

--- a/precompose/src/macosMain/kotlin/moe/tlaster/precompose/ComposeWindow.kt
+++ b/precompose/src/macosMain/kotlin/moe/tlaster/precompose/ComposeWindow.kt
@@ -3,7 +3,6 @@ package moe.tlaster.precompose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.createSkiaLayer
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.native.ComposeLayer
@@ -98,7 +97,6 @@ internal class ComposeWindow(
     val layer = ComposeLayer(
         layer = createSkiaLayer(),
         platform = platform,
-        getTopLeftOffset = { Offset.Zero },
         input = macosTextInputService.input
     )
     val title: String

--- a/precompose/src/uikitMain/kotlin/moe/tlaster/precompose/PreComposeApplication.kt
+++ b/precompose/src/uikitMain/kotlin/moe/tlaster/precompose/PreComposeApplication.kt
@@ -3,6 +3,7 @@ package moe.tlaster.precompose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import androidx.compose.ui.uikit.ComposeUIViewControllerConfiguration
 import androidx.compose.ui.window.ComposeUIViewController
 import moe.tlaster.precompose.lifecycle.LifecycleOwner
 import moe.tlaster.precompose.lifecycle.LifecycleRegistry
@@ -16,10 +17,10 @@ import platform.UIKit.UIViewController
 
 @Suppress("FunctionName")
 fun PreComposeApplication(
-    title: String,
+    configure: ComposeUIViewControllerConfiguration.() -> Unit,
     content: @Composable () -> Unit
 ): UIViewController {
-    return ComposeUIViewController {
+    return ComposeUIViewController(configure) {
         val holder = remember {
             PreComposeWindowHolder()
         }

--- a/precompose/src/uikitMain/kotlin/moe/tlaster/precompose/PreComposeApplication.kt
+++ b/precompose/src/uikitMain/kotlin/moe/tlaster/precompose/PreComposeApplication.kt
@@ -3,7 +3,7 @@ package moe.tlaster.precompose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
-import androidx.compose.ui.window.Application
+import androidx.compose.ui.window.ComposeUIViewController
 import moe.tlaster.precompose.lifecycle.LifecycleOwner
 import moe.tlaster.precompose.lifecycle.LifecycleRegistry
 import moe.tlaster.precompose.lifecycle.LocalLifecycleOwner
@@ -18,9 +18,7 @@ fun PreComposeApplication(
     title: String,
     content: @Composable () -> Unit
 ): UIViewController {
-    return Application(
-        title
-    ) {
+    return ComposeUIViewController {
         val holder = remember {
             PreComposeWindowHolder()
         }

--- a/precompose/src/uikitMain/kotlin/moe/tlaster/precompose/PreComposeApplication.kt
+++ b/precompose/src/uikitMain/kotlin/moe/tlaster/precompose/PreComposeApplication.kt
@@ -17,7 +17,7 @@ import platform.UIKit.UIViewController
 
 @Suppress("FunctionName")
 fun PreComposeApplication(
-    configure: ComposeUIViewControllerConfiguration.() -> Unit ={},
+    configure: ComposeUIViewControllerConfiguration.() -> Unit = {},
     content: @Composable () -> Unit
 ): UIViewController {
     return ComposeUIViewController(configure) {

--- a/precompose/src/uikitMain/kotlin/moe/tlaster/precompose/PreComposeApplication.kt
+++ b/precompose/src/uikitMain/kotlin/moe/tlaster/precompose/PreComposeApplication.kt
@@ -17,7 +17,7 @@ import platform.UIKit.UIViewController
 
 @Suppress("FunctionName")
 fun PreComposeApplication(
-    configure: ComposeUIViewControllerConfiguration.() -> Unit,
+    configure: ComposeUIViewControllerConfiguration.() -> Unit ={},
     content: @Composable () -> Unit
 ): UIViewController {
     return ComposeUIViewController(configure) {

--- a/precompose/src/uikitMain/kotlin/moe/tlaster/precompose/PreComposeApplication.kt
+++ b/precompose/src/uikitMain/kotlin/moe/tlaster/precompose/PreComposeApplication.kt
@@ -14,6 +14,7 @@ import moe.tlaster.precompose.ui.BackDispatcherOwner
 import moe.tlaster.precompose.ui.LocalBackDispatcherOwner
 import platform.UIKit.UIViewController
 
+@Suppress("FunctionName")
 fun PreComposeApplication(
     title: String,
     content: @Composable () -> Unit

--- a/sample/molecule/src/uikitMain/kotlin/moe/tlaster/precompose/molecule/sample/Main.kt
+++ b/sample/molecule/src/uikitMain/kotlin/moe/tlaster/precompose/molecule/sample/Main.kt
@@ -34,7 +34,7 @@ class SkikoAppDelegate : UIResponder, UIApplicationDelegateProtocol {
 
     override fun application(application: UIApplication, didFinishLaunchingWithOptions: Map<Any?, *>?): Boolean {
         window = UIWindow(frame = UIScreen.mainScreen.bounds).apply {
-            rootViewController = PreComposeApplication("PreCompose Molecule Sample") {
+            rootViewController = PreComposeApplication {
                 App()
             }
             makeKeyAndVisible()

--- a/sample/todo/ios/src/uikitMain/kotlin/main.uikit.kt
+++ b/sample/todo/ios/src/uikitMain/kotlin/main.uikit.kt
@@ -47,7 +47,7 @@ class SkikoAppDelegate : UIResponder, UIApplicationDelegateProtocol {
 
     override fun application(application: UIApplication, didFinishLaunchingWithOptions: Map<Any?, *>?): Boolean {
         window = UIWindow(frame = UIScreen.mainScreen.bounds).apply {
-            rootViewController = PreComposeApplication("PreCompose") {
+            rootViewController = PreComposeApplication {
                 Column {
                     Spacer(
                         modifier = Modifier


### PR DESCRIPTION
# Updated Libraries
This includes updates to the following:
| Library | From | To |
|--------|--------|--------|
| Kotlin | 1.8.2 | 1.9.0 |
| Coroutines | 1.7.1 | 1.7.3 |
| Compose | 1.4.2 | 1.5.0-beta03 |
| Jetbrains Compose | 1.4.0 | 1.5.0-dev1122 | 
| AndroidX Activity | 1.7.0 | 1.7.2 | 

# Changes
`AnimatedContentScope` was converted to an Interface so now we need to use `AnimatedContentTransitionScope`

`EnterTransition` `with` is deprecated and replaced by `togetherWith`

`ComposeUIViewController` replaces `Application` on iOS and title string parameter is no longer used so removed.


# Validations
I'm running this in a new project targeting Android, iOS & JVM. My project is running and navigating on each platform. Publish and test gradle commands succeed.

Note:
This is my first time submitting a PR to an OSS project. Please let me know how I can help.