### PR TITLE
Refactor Android PreComposeActivity to ComponentAcitivity extensions

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -18,7 +18,7 @@ api("moe.tlaster:precompose:$precompose_version")
 // api("moe.tlaster:precompose-koin:$precompose_version") // For Koin intergration
 ```
 ## Android
-Change the Activity's parent class to `moe.tlaster.precompose.lifecycle.PreComposeActivity` and use `moe.tlaster.precompose.lifecycle.setContent` for setting compose content
+Change the `androidx.activity.compose.setContent` to `moe.tlaster.precompose.lifecycle.setContent`
 
 ## Desktop (JVM)
 Change the `Window` to `moe.tlaster.precompose.PreComposeWindow`

--- a/sample/molecule/src/androidMain/kotlin/moe/tlaster/precompose/molecule/sample/MainActivity.kt
+++ b/sample/molecule/src/androidMain/kotlin/moe/tlaster/precompose/molecule/sample/MainActivity.kt
@@ -1,10 +1,10 @@
 package moe.tlaster.precompose.molecule.sample
 
 import android.os.Bundle
-import moe.tlaster.precompose.lifecycle.PreComposeActivity
+import androidx.fragment.app.FragmentActivity
 import moe.tlaster.precompose.lifecycle.setContent
 
-class MainActivity : PreComposeActivity() {
+class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {

--- a/sample/todo/android/src/main/java/moe/tlaster/android/MainActivity.kt
+++ b/sample/todo/android/src/main/java/moe/tlaster/android/MainActivity.kt
@@ -1,13 +1,11 @@
 package moe.tlaster.android
 
 import android.os.Bundle
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.activity.ComponentActivity
 import moe.tlaster.common.App
-import moe.tlaster.precompose.lifecycle.PreComposeActivity
 import moe.tlaster.precompose.lifecycle.setContent
 
-class MainActivity : PreComposeActivity() {
-    @OptIn(ExperimentalMaterialApi::class)
+class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {


### PR DESCRIPTION
Now you don’t need to inherit from PreComposeActivity, you just need to use the setContent function.
In samples, the PreComposeActivity classes have been changed into two variations: ComponentActivity and FragmentActivity.
Maybe you will need to change the file name PreComposeActivity.kt to something else.

Also if this is a good replacement I'll edit the documentation as well.