### PR TITLE
Avoid composing scene multiple times due to BackStackEntry

### DIFF
--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/RouteBuilder.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/RouteBuilder.kt
@@ -1,6 +1,9 @@
 package moe.tlaster.precompose.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import moe.tlaster.precompose.navigation.route.FloatingRoute
 import moe.tlaster.precompose.navigation.route.GroupRoute
 import moe.tlaster.precompose.navigation.route.Route
@@ -11,6 +14,24 @@ class RouteBuilder(
     private val initialRoute: String,
 ) {
     private val route = arrayListOf<Route>()
+
+    private fun sceneInternal(
+        route: String,
+        deepLinks: List<String>,
+        navTransition: NavTransition?,
+        swipeProperties: SwipeProperties?,
+        content: @Composable (State<BackStackEntry>) -> Unit,
+    ) {
+        addRoute(
+            SceneRoute(
+                route = route,
+                navTransition = navTransition,
+                deepLinks = deepLinks,
+                swipeProperties = swipeProperties,
+                content = { content(remember { mutableStateOf(it) }) },
+            ),
+        )
+    }
 
     /**
      * Add the scene [Composable] to the [RouteBuilder]
@@ -26,14 +47,12 @@ class RouteBuilder(
         swipeProperties: SwipeProperties? = null,
         content: @Composable (BackStackEntry) -> Unit,
     ) {
-        addRoute(
-            SceneRoute(
-                route = route,
-                navTransition = navTransition,
-                deepLinks = deepLinks,
-                swipeProperties = swipeProperties,
-                content = content,
-            ),
+        sceneInternal(
+            route = route,
+            navTransition = navTransition,
+            deepLinks = deepLinks,
+            swipeProperties = swipeProperties,
+            content = { content(it.value) },
         )
     }
 
@@ -74,6 +93,18 @@ class RouteBuilder(
         )
     }
 
+    private fun floatingInternal(
+        route: String,
+        content: @Composable (State<BackStackEntry>) -> Unit,
+    ) {
+        addRoute(
+            FloatingRoute(
+                route = route,
+                content = { content(remember { mutableStateOf(it) }) },
+            ),
+        )
+    }
+
     /**
      * Add the floating [Composable] to the [RouteBuilder], which will show over the scene
      * @param route route for the destination
@@ -83,11 +114,9 @@ class RouteBuilder(
         route: String,
         content: @Composable (BackStackEntry) -> Unit,
     ) {
-        addRoute(
-            FloatingRoute(
-                route = route,
-                content = content,
-            ),
+        floatingInternal(
+            route = route,
+            content = { content(it.value) },
         )
     }
 


### PR DESCRIPTION
This PR tries to mitigate #134.

Wrapping the `BackStackEntry` in a mutable state will make it `Stable` avoiding triggering recompositions when interacting with it.