### PR TITLE
Fix flicker on screen transition with PopUpTo with inclusive true.

### DIFF
--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackStackManager.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackStackManager.kt
@@ -150,7 +150,7 @@ internal class BackStackManager : LifecycleObserver {
                 )
                 backStacks.value -= stacksToDrop
                 stacksToDrop.forEach {
-                    it.destroyDirectly()
+                    it.destroy()
                 }
             }
         }

--- a/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/BackStackManagerTest.kt
+++ b/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/BackStackManagerTest.kt
@@ -581,9 +581,17 @@ class BackStackManagerTest {
             lifecycleOwner = lifecycleOwner,
             persistNavState = false,
         )
-        manager.push("screen2")
-        manager.push("screen1", NavOptions(popUpTo = PopUpTo("screen1")))
-        manager.push("screen1")
+
+        fun navigate(path: String, navOptions: NavOptions) {
+            val previousEntry = manager.backStacks.value.lastOrNull()
+            manager.push(path, navOptions)
+            // Mark the previous entry as inactive to simulate the lifecycle change by the NavHost
+            previousEntry?.inActive()
+        }
+
+        navigate("screen2", NavOptions())
+        navigate("screen1", NavOptions(popUpTo = PopUpTo("screen1")))
+        navigate("screen1", NavOptions())
 
         assertEquals(
             listOf("screen1", "screen1", "screen1"),


### PR DESCRIPTION
When performing a screen transition from `Screen A` to the same `Screen A`, with `PopUpTo` with `inclusive` true, `destroyDirectly` will cause a flicker of the screen. 

```kotlin
navigator.navigate(
    route = "Screen A",
    popUpTo = PopUpTo(
        route = "Screen A", 
        inclusive = true,
    )
)
```

If we change it to `destroy`, it will only destroy the composable only when `Inactive` and it still won't crash as mentioned in 
https://github.com/Tlaster/PreCompose/issues/146.
