### PR TITLE
Fix Molecule sample "No StateHolder provided"

### DIFF
--- a/sample/molecule/src/commonMain/kotlin/moe/tlaster/precompose/molecule/sample/App.kt
+++ b/sample/molecule/src/commonMain/kotlin/moe/tlaster/precompose/molecule/sample/App.kt
@@ -14,32 +14,35 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import moe.tlaster.precompose.PreComposeApp
 import moe.tlaster.precompose.molecule.producePresenter
 
 @Composable
 fun App() {
-    val state by producePresenter { Presenter() }
-    MaterialTheme {
-        Scaffold {
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Text(text = state.count)
-                Button(
-                    onClick = {
-                        state.action(Action.Increment)
-                    },
+    PreComposeApp {
+        val state by producePresenter { Presenter() }
+        MaterialTheme {
+            Scaffold {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
                 ) {
-                    Text(text = "Increment")
-                }
-                Button(
-                    onClick = {
-                        state.action(Action.Decrement)
-                    },
-                ) {
-                    Text(text = "Decrement")
+                    Text(text = state.count)
+                    Button(
+                        onClick = {
+                            state.action(Action.Increment)
+                        },
+                    ) {
+                        Text(text = "Increment")
+                    }
+                    Button(
+                        onClick = {
+                            state.action(Action.Decrement)
+                        },
+                    ) {
+                        Text(text = "Decrement")
+                    }
                 }
             }
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,7 @@ dependencyResolutionManagement {
         maven("https://jitpack.io")
     }
 }
-rootProject.name = "PreCompose"
+rootProject.name = "precompose"
 
 include(":precompose")
 include(":precompose-viewmodel")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,7 @@ dependencyResolutionManagement {
         maven("https://jitpack.io")
     }
 }
-rootProject.name = "precompose"
+rootProject.name = "PreCompose"
 
 include(":precompose")
 include(":precompose-viewmodel")


### PR DESCRIPTION
The Molecule sample app crashes on desktop and Android:
![image](https://github.com/Tlaster/PreCompose/assets/35243139/780b28ed-36c0-404d-b242-f8535b1fb65b)

This PR just wraps contents of `App` in `PreComposeApp` as in the other sample.