### PR TITLE
Update documentation for JDK 11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ For those able & willing to help fix issues and/or implement features ...
 ### Development environment
 
 Make sure you have
- - JDK 17  
+ - JDK 11  
  - A Mac if you're developing Compose for iOS/macOS
 
 ### Code guidelines

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ allprojects {
 extra.apply {
     set("precomposeVersion", "1.5.10")
 
-    set("jvmTarget", "17")
+    set("jvmTarget", "11")
 
     // Android configurations
     set("android-compile", 34)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ allprojects {
 extra.apply {
     set("precomposeVersion", "1.5.10")
 
-    set("jvmTarget", "11")
+    set("jvmTarget", "17")
 
     // Android configurations
     set("android-compile", 34)


### PR DESCRIPTION
According to the [CONTRIBUTING.md](/Tlaster/PreCompose/blob/master/CONTRIBUTING.md#development-environment) file, we should have at least the JDK 17 to compile the project.
However, the current setup is pointing to JDK 11, which prevents the project from compiling with JDK 17.
