### PR TITLE
Introduce a name to remember Navigator

### DIFF
--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/Navigator.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/Navigator.kt
@@ -8,13 +8,14 @@ import moe.tlaster.precompose.stateholder.SavedStateHolder
 import moe.tlaster.precompose.stateholder.StateHolder
 
 /**
- * Creates a [Navigator] that controls the [NavHost].
+ * Creates or returns an existing [Navigator] that controls the [NavHost].
+ * @param name: Identify the navigator so you can have as many navigator instances as you need.
  * @return Returns an instance of Navigator.
  */
 @Composable
-fun rememberNavigator(): Navigator {
+fun rememberNavigator(name: String = ""): Navigator {
     val stateHolder = LocalStateHolder.current
-    return stateHolder.getOrPut("Navigator") {
+    return stateHolder.getOrPut("${name}Navigator") {
         Navigator()
     }
 }


### PR DESCRIPTION
This allows us to have multiple instances of navigators whenever we need them.

For example, when using multiple NavHosts:

```kotlin
val mainNavigator = rememberNavigator(name = "main")
val homeNavigator = rememberNavigator(name = "home")

NavHost(
    navigator = mainNavigator,
    initialRoute = "home",
)
NavHost(
    navigator = homeNavigator,
    initialRoute = "dashboard",
)
```