### PR TITLE
Remove confusing API from goBack

### DIFF
--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackStackManager.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/BackStackManager.kt
@@ -188,7 +188,6 @@ internal class BackStackManager : LifecycleObserver {
 
     fun popWithOptions(
         popUpTo: PopUpTo,
-        inclusive: Boolean,
     ) {
         if (!canNavigate) {
             return
@@ -206,7 +205,7 @@ internal class BackStackManager : LifecycleObserver {
                 0
             }
         }.let {
-            if (inclusive) it else it + 1
+            if (popUpTo.inclusive) it else it + 1
         }.let {
             max(it, 0)
         }

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/Navigator.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/Navigator.kt
@@ -112,16 +112,14 @@ class Navigator {
     /**
      * Go back to a specific destination.
      * @param popUpTo: the destination to pop back to.
-     * @param inclusive: includes the destination to pop back to in the back stack.
      */
     fun goBack(
         popUpTo: PopUpTo,
-        inclusive: Boolean,
     ) {
         if (!_initialized) {
             return
         }
-        stackManager.popWithOptions(popUpTo, inclusive)
+        stackManager.popWithOptions(popUpTo)
     }
 
     /**

--- a/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/BackStackManagerTest.kt
+++ b/precompose/src/commonTest/kotlin/moe/tlaster/precompose/navigation/BackStackManagerTest.kt
@@ -561,7 +561,7 @@ class BackStackManagerTest {
         manager.push("screen2")
         manager.push("screen3")
 
-        manager.popWithOptions(PopUpTo("screen1"), inclusive = false)
+        manager.popWithOptions(PopUpTo("screen1", inclusive = false))
 
         assertEquals(
             listOf("screen1"),
@@ -598,7 +598,7 @@ class BackStackManagerTest {
         manager.push("screen2")
         manager.push("screen3")
 
-        manager.popWithOptions(PopUpTo("screen2"), inclusive = true)
+        manager.popWithOptions(PopUpTo("screen2", inclusive = true))
 
         assertEquals(
             listOf("screen1"),


### PR DESCRIPTION
Having `PopUpTo` as a parameter in the `goBack` function with an `inclusive` flag adds complexity.

Providing multiple values for this operation can lead to confusion.