### PR TITLE
Stylianos: shared element experiment [DO NOT MERGE]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application).apply(false)
     alias(libs.plugins.android.library).apply(false)
     alias(libs.plugins.kotlin.multiplatform).apply(false)
+    alias(libs.plugins.kotlin.android).apply(false)
     alias(libs.plugins.spotless)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ kotlinxCoroutinesCore = "1.8.0"
 moleculeRuntime = "1.3.2"
 savedstateKtx = "1.2.1"
 spotless = "6.25.0"
-jetbrainsComposePlugin = "1.6.0"
+jetbrainsComposePlugin = "1.6.10-dev1580"
 skiko = "0.7.93"
 koin = "3.6.0-alpha3"
 uuid = "0.8.2"
@@ -48,5 +48,6 @@ uuid = { module = "com.benasher44:uuid", version.ref = "uuid" }
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 jetbrains-compose = { id = "org.jetbrains.compose", version.ref = "jetbrainsComposePlugin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/NavHost.kt
@@ -1,6 +1,7 @@
 package moe.tlaster.precompose.navigation
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.core.ExperimentalTransitionApi
@@ -234,7 +235,7 @@ fun NavHost(
                 transitionSpec = transitionSpec,
                 contentKey = { it.stateId },
             ) { entry ->
-                NavHostContent(composeStateHolder, entry)
+                NavHostContent(composeStateHolder, entry, this)
             }
             if (state != null) {
                 DragSlider(
@@ -250,7 +251,7 @@ fun NavHost(
                 it,
                 contentKey = { it.stateId },
             ) { entry ->
-                NavHostContent(composeStateHolder, entry)
+                NavHostContent(composeStateHolder, entry, this)
             }
         }
     }
@@ -260,6 +261,7 @@ fun NavHost(
 private fun NavHostContent(
     stateHolder: SaveableStateHolder,
     entry: BackStackEntry,
+    animatedContentScope: AnimatedContentScope,
 ) {
     stateHolder.SaveableStateProvider(entry.stateId) {
         CompositionLocalProvider(
@@ -267,7 +269,7 @@ private fun NavHostContent(
             LocalSavedStateHolder provides entry.savedStateHolder,
             LocalLifecycleOwner provides entry,
             content = {
-                entry.ComposeContent()
+                entry.ComposeContent(animatedContentScope)
             },
         )
     }
@@ -288,12 +290,12 @@ private fun GroupRoute.composeRoute(): ComposeRoute? {
 }
 
 @Composable
-private fun BackStackEntry.ComposeContent() {
+private fun BackStackEntry.ComposeContent(animatedContentScope: AnimatedContentScope) {
     if (route is GroupRoute) {
         (route as GroupRoute).composeRoute()
     } else {
         route as? ComposeRoute
-    }?.content?.invoke(this)
+    }?.content?.invoke(animatedContentScope, this)
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/RouteBuilder.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/RouteBuilder.kt
@@ -1,5 +1,7 @@
 package moe.tlaster.precompose.navigation
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.runtime.Composable
 import moe.tlaster.precompose.navigation.route.FloatingRoute
 import moe.tlaster.precompose.navigation.route.GroupRoute
@@ -19,12 +21,43 @@ class RouteBuilder(
      * @param swipeProperties swipe back navigation properties for current scene
      * @param content composable for the destination
      */
+    @Deprecated(
+        message = "Deprecated in favor of composable builder that supports AnimatedContent",
+        level = DeprecationLevel.HIDDEN
+    )
     fun scene(
         route: String,
         deepLinks: List<String> = emptyList(),
         navTransition: NavTransition? = null,
         swipeProperties: SwipeProperties? = null,
         content: @Composable (BackStackEntry) -> Unit,
+    ) {
+        addRoute(
+            SceneRoute(
+                route = route,
+                navTransition = navTransition,
+                deepLinks = deepLinks,
+                swipeProperties = swipeProperties,
+                content = { backStackEntry ->
+                    AnimatedContent(Unit) { content(backStackEntry) }
+                },
+            ),
+        )
+    }
+
+    /**
+     * Add the scene [Composable] to the [RouteBuilder]
+     * @param route route for the destination
+     * @param navTransition navigation transition for current scene
+     * @param swipeProperties swipe back navigation properties for current scene
+     * @param content composable for the destination
+     */
+    fun scene(
+        route: String,
+        deepLinks: List<String> = emptyList(),
+        navTransition: NavTransition? = null,
+        swipeProperties: SwipeProperties? = null,
+        content: @Composable AnimatedContentScope.(BackStackEntry) -> Unit,
     ) {
         addRoute(
             SceneRoute(
@@ -88,7 +121,9 @@ class RouteBuilder(
         addRoute(
             FloatingRoute(
                 route = route,
-                content = content,
+                content = { backStackEntry ->
+                    AnimatedContent(Unit) { content(backStackEntry) }
+                },
             ),
         )
     }

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/route/ComposeRoute.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/route/ComposeRoute.kt
@@ -1,10 +1,11 @@
 package moe.tlaster.precompose.navigation.route
 
+import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.runtime.Composable
 import moe.tlaster.precompose.navigation.BackStackEntry
 
 interface ComposeRoute : Route {
-    val content: @Composable (BackStackEntry) -> Unit
+    val content: @Composable AnimatedContentScope.(BackStackEntry) -> Unit
 }
 
 interface ComposeSceneRoute : ComposeRoute

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/route/FloatingRoute.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/route/FloatingRoute.kt
@@ -1,9 +1,10 @@
 package moe.tlaster.precompose.navigation.route
 
+import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.runtime.Composable
 import moe.tlaster.precompose.navigation.BackStackEntry
 
 internal class FloatingRoute(
-    override val content: @Composable (BackStackEntry) -> Unit,
+    override val content: @Composable AnimatedContentScope.(BackStackEntry) -> Unit,
     override val route: String,
 ) : ComposeRoute, ComposeFloatingRoute

--- a/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/route/SceneRoute.kt
+++ b/precompose/src/commonMain/kotlin/moe/tlaster/precompose/navigation/route/SceneRoute.kt
@@ -1,5 +1,6 @@
 package moe.tlaster.precompose.navigation.route
 
+import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.runtime.Composable
 import moe.tlaster.precompose.navigation.BackStackEntry
 import moe.tlaster.precompose.navigation.SwipeProperties
@@ -10,5 +11,5 @@ internal class SceneRoute(
     val deepLinks: List<String>,
     val navTransition: NavTransition?,
     val swipeProperties: SwipeProperties?,
-    override val content: @Composable (BackStackEntry) -> Unit,
+    override val content: @Composable AnimatedContentScope.(BackStackEntry) -> Unit,
 ) : ComposeRoute, ComposeSceneRoute

--- a/sample/shared-elements/build.gradle.kts
+++ b/sample/shared-elements/build.gradle.kts
@@ -1,0 +1,46 @@
+plugins {
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.jetbrains.compose)
+  alias(libs.plugins.kotlin.android)
+}
+
+android {
+  compileSdk = rootProject.extra.get("android-compile") as Int
+  buildToolsVersion = rootProject.extra.get("android-build-tools") as String
+  defaultConfig {
+    applicationId = "moe.tlaster.sample.shared.elements"
+    minSdk = rootProject.extra.get("androidMinSdk") as Int
+    targetSdk = rootProject.extra.get("androidTargetSdk") as Int
+    versionCode = 1
+    versionName = "0.1.0"
+  }
+  buildTypes {
+    getByName("release") {
+      isMinifyEnabled = false
+    }
+  }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+  namespace = "moe.tlaster.sample.shared.elements"
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_17.toString()
+    allWarningsAsErrors = true
+    freeCompilerArgs = listOf(
+      "-opt-in=kotlin.RequiresOptIn",
+    )
+  }
+}
+
+//noinspection UseTomlInstead
+dependencies {
+  implementation("androidx.compose.animation:animation-core:1.7.0-SNAPSHOT")
+  implementation("androidx.compose.ui:ui:1.7.0-SNAPSHOT")
+  implementation("androidx.compose.foundation:foundation:1.7.0-SNAPSHOT")
+  implementation(libs.androidx.activity.compose)
+  implementation(project(":precompose"))
+}

--- a/sample/shared-elements/src/main/AndroidManifest.xml
+++ b/sample/shared-elements/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:enableOnBackInvokedCallback="false"
+        android:label="PreCompose Sample"
+        android:supportsRtl="true"
+        android:name=".SharedElementsApplication"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar"
+        tools:targetApi="tiramisu"
+        tools:ignore="MissingApplicationIcon">
+        <activity
+            android:name=".MainActivity"
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/sample/shared-elements/src/main/java/moe/tlaster/sample/shared/elements/MainActivity.kt
+++ b/sample/shared-elements/src/main/java/moe/tlaster/sample/shared/elements/MainActivity.kt
@@ -1,0 +1,190 @@
+@file:OptIn(ExperimentalSharedTransitionApi::class)
+
+package moe.tlaster.sample.shared.elements
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.animation.BoundsTransform
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.SharedTransitionScope.PlaceHolderSize.Companion.contentSize
+import androidx.compose.animation.core.Spring.StiffnessMediumLow
+import androidx.compose.animation.core.VisibilityThreshold
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import moe.tlaster.precompose.PreComposeApp
+import moe.tlaster.precompose.navigation.NavHost
+import moe.tlaster.precompose.navigation.path
+import moe.tlaster.precompose.navigation.rememberNavigator
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+        setContent {
+            PreComposeApp {
+                App()
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+private fun App() {
+    SharedTransitionLayout(Modifier.fillMaxSize()) {
+        val navigator = rememberNavigator()
+        NavHost(
+            navigator,
+            "a",
+            Modifier.fillMaxSize()
+        ) {
+            scene("a") {
+                with(SharedElementsScope(this@SharedTransitionLayout, this)) {
+                    Box(Modifier.fillMaxSize()) {
+                        A(navigateToB = { index -> navigator.navigate("b/$index") })
+                    }
+                }
+            }
+            scene(
+                "b/{id}",
+            ) { backStackEntry ->
+                val index: Int = backStackEntry.path<Int>("id")!!
+                with(SharedElementsScope(this@SharedTransitionLayout, this)) {
+                    Box(Modifier.fillMaxSize()) {
+                        B(colors[index])
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SharedElementsScope.A(
+    navigateToB: (index: Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        for ((index, color) in colors.withIndex()) {
+            Card(
+                color,
+                Modifier
+                    .padding(16.dp)
+                    .background(color)
+                    .clickable { navigateToB(index) }
+                    .sharedElement(this@A, rememberSharedContentState(color.toString()))
+            ) {
+                BasicText("Color:#${color.value}")
+            }
+        }
+    }
+}
+
+@Composable
+private fun SharedElementsScope.B(color: Color, modifier: Modifier = Modifier) {
+    Card(
+        color,
+        modifier
+            .fillMaxSize()
+            .wrapContentSize()
+            .sharedElement(this, rememberSharedContentState(color.toString()))
+    ) {
+        BasicText("Color:#${color.value}")
+    }
+}
+
+@Composable
+private fun Card(color: Color, modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Box(modifier.fillMaxWidth().height(50.dp).background(color)) {
+        content()
+    }
+}
+
+private val colors = listOf(
+    Color.Gray,
+    Color.LightGray,
+    Color.White,
+    Color.Red,
+    Color.Green,
+    Color.Blue,
+    Color.Yellow,
+    Color.Cyan,
+    Color.Magenta,
+)
+
+private class SharedElementsScope(
+    val sharedTransitionScope: SharedTransitionScope,
+    val animatedContentScope: AnimatedContentScope,
+)
+
+@Composable
+private fun SharedElementsScope.rememberSharedContentState(key: Any): SharedTransitionScope.SharedContentState {
+    return with(sharedTransitionScope) {
+        rememberSharedContentState(key)
+    }
+}
+
+private fun Modifier.sharedElement(
+    sharedElementsScope: SharedElementsScope,
+    state: SharedTransitionScope.SharedContentState,
+    boundsTransform: BoundsTransform = DefaultBoundsTransform,
+    placeHolderSize: SharedTransitionScope.PlaceHolderSize = contentSize,
+    renderInOverlayDuringTransition: Boolean = true,
+    zIndexInOverlay: Float = 0f,
+    clipInOverlayDuringTransition: SharedTransitionScope.OverlayClip = ParentClip
+) = with(sharedElementsScope) {
+    with(sharedTransitionScope) {
+        this@sharedElement.sharedElement(
+            state = state,
+            animatedVisibilityScope = animatedContentScope,
+            boundsTransform = boundsTransform,
+            placeHolderSize = placeHolderSize,
+            renderInOverlayDuringTransition = renderInOverlayDuringTransition,
+            zIndexInOverlay = zIndexInOverlay,
+            clipInOverlayDuringTransition = clipInOverlayDuringTransition,
+        )
+    }
+}
+
+private val ParentClip: SharedTransitionScope.OverlayClip =
+    object : SharedTransitionScope.OverlayClip {
+        override fun getClipPath(
+            state: SharedTransitionScope.SharedContentState,
+            bounds: Rect,
+            layoutDirection: LayoutDirection,
+            density: Density
+        ): Path? {
+            return state.parentSharedContentState?.clipPathInOverlay
+        }
+    }
+private val DefaultBoundsTransform = BoundsTransform { _, _ -> DefaultSpring }
+private val DefaultSpring = spring(
+    stiffness = StiffnessMediumLow,
+    visibilityThreshold = Rect.VisibilityThreshold
+)

--- a/sample/shared-elements/src/main/java/moe/tlaster/sample/shared/elements/MainActivity.kt
+++ b/sample/shared-elements/src/main/java/moe/tlaster/sample/shared/elements/MainActivity.kt
@@ -96,7 +96,6 @@ private fun SharedElementsScope.A(
                 color,
                 Modifier
                     .padding(16.dp)
-                    .background(color)
                     .clickable { navigateToB(index) }
                     .sharedElement(this@A, rememberSharedContentState(color.toString()))
             ) {

--- a/sample/shared-elements/src/main/java/moe/tlaster/sample/shared/elements/SharedElementsApplication.kt
+++ b/sample/shared-elements/src/main/java/moe/tlaster/sample/shared/elements/SharedElementsApplication.kt
@@ -1,0 +1,5 @@
+package moe.tlaster.sample.shared.elements
+
+import android.app.Application
+
+class SharedElementsApplication : Application()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,8 @@ dependencyResolutionManagement {
         maven("https://jitpack.io")
         // TODO: delete when we have all libs in mavenCentral
         maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
+        // TODO: remove after shared elements are no longer only in snapshots
+        maven("https://androidx.dev/snapshots/builds/11722689/artifacts/repository")
     }
 }
 rootProject.name = "precompose"
@@ -33,3 +35,4 @@ include(":sample:todo:ios")
 include(":sample:todo:macos")
 include(":sample:todo:js")
 include(":sample:molecule")
+include(":sample:shared-elements")


### PR DESCRIPTION
This is a sample added to support my case for https://github.com/Tlaster/PreCompose/issues/308
The one thing which I would like this library to do is to expose the already used `AnimatedContentScope`.
That would then allow callers to use it in their `sharedElement` modifiers.
The APIs are not there yet for compose multiplatform as I explain further down and in the sample commit, but this library can make this API change to prepare for the future where the APIs are there.

Note that the changes I make in the library itself are not meant to stay as-is. I hacked away a bit by wrapping the existing DSL functions to just wrap the content with an empty `AnimatedContent {}` block which is probably not what should really be done here to support this change.

For the real impl I support some inspiration can be taken from what the real androidx.navigation library has done here https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavGraphBuilder.kt;l=46-55 by deprecating the old functions and showing only the new ones, while keeping backwards compatibility with the old one.

Note that the sample crashes when going back since
SeekableTransitionState from google's compose
and SeekableTransitionState from jetbrains compose
have a breaking API change between them, making it
impossible to call it at runtime.

This will be fixed as soon as Jetbrains compose
catches up with those breaking changes. This should
not be a concern of this library however in order to
support its users to use the provided
AnimatedContentScope

I attach a video of the sample playing here, again, only going forward due to the aforementioned bug to show what I would like to be possible to be done in the future with PreCompose 😊

https://github.com/Tlaster/PreCompose/assets/44558292/c2e727cb-0e26-4d0b-8f06-97376c12542e


