### PR TITLE
handle lifecycle in JS targets

### DIFF
--- a/precompose/src/jsMain/kotlin/moe/tlaster/precompose/PreComposeWindow.kt
+++ b/precompose/src/jsMain/kotlin/moe/tlaster/precompose/PreComposeWindow.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.window.CanvasBasedWindow
+import moe.tlaster.precompose.lifecycle.Lifecycle
 import moe.tlaster.precompose.lifecycle.LifecycleOwner
 import moe.tlaster.precompose.lifecycle.LifecycleRegistry
 import moe.tlaster.precompose.lifecycle.LocalLifecycleOwner
@@ -73,5 +74,9 @@ class PreComposeWindowHolder : LifecycleOwner, BackDispatcherOwner {
     }
     override val backDispatcher by lazy {
         BackDispatcher()
+    }
+
+    init {
+        lifecycle.updateState(Lifecycle.State.Active)
     }
 }

--- a/precompose/src/wasmJsMain/kotlin/moe/tlaster/precompose/PreComposeApp.kt
+++ b/precompose/src/wasmJsMain/kotlin/moe/tlaster/precompose/PreComposeApp.kt
@@ -3,6 +3,7 @@ package moe.tlaster.precompose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import moe.tlaster.precompose.lifecycle.Lifecycle
 import moe.tlaster.precompose.lifecycle.LifecycleOwner
 import moe.tlaster.precompose.lifecycle.LifecycleRegistry
 import moe.tlaster.precompose.lifecycle.LocalLifecycleOwner
@@ -46,5 +47,9 @@ class PreComposeWindowHolder : LifecycleOwner, BackDispatcherOwner {
     }
     override val backDispatcher by lazy {
         BackDispatcher()
+    }
+
+    init {
+        lifecycle.updateState(Lifecycle.State.Active)
     }
 }


### PR DESCRIPTION
Hi I have found exact the same issue as in #98 but for JS targets.

Lifecycle for JS targets is not initialised with Active state so collect is not not grabbing any events.
I have found this issue when working on JS support for typesfe navigation 

Lavmee/precompose-navigation-typesafe#36


```
val navigator = rememberNavigator()
val currentEntry by navigator.currentEntry.collectAsStateWithLifecycle(null)
```

This PR fixes the issue and moves lifecycle to active state after creation of PreComposeWindowHolder

before

https://github.com/user-attachments/assets/78f50383-29b7-4531-b88f-98e3575b085a


after

https://github.com/user-attachments/assets/028a8b4e-089a-42ce-8fa2-176da0119923

