### PR TITLE
added support for molecule for js wasm

### DIFF
--- a/precompose-molecule/build.gradle.kts
+++ b/precompose-molecule/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 import java.util.Properties
 
 plugins {
@@ -29,6 +30,10 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
     js(IR) {
+        browser()
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
         browser()
     }
     sourceSets {

--- a/precompose-molecule/src/wasmJsMain/kotlin/moe/tlaster/precompose/molecule/ProvidePlatformDispatcher.kt
+++ b/precompose-molecule/src/wasmJsMain/kotlin/moe/tlaster/precompose/molecule/ProvidePlatformDispatcher.kt
@@ -1,0 +1,6 @@
+package moe.tlaster.precompose.molecule
+
+import kotlinx.coroutines.Dispatchers
+import kotlin.coroutines.CoroutineContext
+
+internal actual fun providePlatformDispatcher(): CoroutineContext = Dispatchers.Main

--- a/sample/molecule/build.gradle.kts
+++ b/sample/molecule/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
 plugins {
     kotlin("multiplatform")
@@ -37,6 +39,25 @@ kotlin {
         }
     }
     jvm()
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        moduleName = "composeApp"
+        browser {
+            val projectDirPath = project.projectDir.path
+            commonWebpackConfig {
+                outputFileName = "composeApp.js"
+                devServer =
+                    (devServer ?: KotlinWebpackConfig.DevServer()).apply {
+                        static =
+                            (static ?: mutableListOf()).apply {
+                                // Serve sources to debug inside browser
+                                add(projectDirPath)
+                            }
+                    }
+            }
+        }
+        binaries.executable()
+    }
 
     sourceSets {
         val commonMain by getting {

--- a/sample/molecule/src/wasmJsMain/kotlin/moe/tlaster/precompose/molecule/sample/Main.kt
+++ b/sample/molecule/src/wasmJsMain/kotlin/moe/tlaster/precompose/molecule/sample/Main.kt
@@ -1,0 +1,12 @@
+package moe.tlaster.precompose.molecule.sample
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.ComposeViewport
+import kotlinx.browser.document
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    ComposeViewport(document.body!!) {
+        App()
+    }
+}

--- a/sample/molecule/src/wasmJsMain/resources/index.html
+++ b/sample/molecule/src/wasmJsMain/resources/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>molecule</title>
+    <link type="text/css" rel="stylesheet" href="styles.css">
+    <script type="application/javascript" src="composeApp.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/sample/molecule/src/wasmJsMain/resources/styles.css
+++ b/sample/molecule/src/wasmJsMain/resources/styles.css
@@ -1,0 +1,7 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}


### PR DESCRIPTION
When imported molecule package I have noticed that it misses wasm support.
This PR:

- adds wasm support for precompose-molecule package
- adds wasm target for molecule sample


https://github.com/user-attachments/assets/cc022461-6997-49c1-966e-77bc0a6bff0e

